### PR TITLE
Use gcc, fix paths, add --with-java, add README.md (fix #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,118 @@
+# Homebrew Formula for PDFtk Server
+
+This is a [Homebrew](http://brew.sh/) formula for [PDFtk
+Server](https://www.pdflabs.com/tools/pdftk-server/), the
+[GPL-licensed](https://www.pdflabs.com/docs/pdftk-license/) version of
+[PDFtk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/), a PDF toolkit.
+
+## Features
+
+From the [PDFtk Server website](https://www.pdflabs.com/tools/pdftk-server/),
+PDFtk Server can:
+
+* Merge PDF documents or collate PDF page scans
+* Split PDF pages into a new document
+* Rotate PDF documents or pages
+* Decrypt input as necessary (password required)
+* Encrypt output as desired
+* Fill PDF forms with X/FDF data and/or flatten forms
+* Generate FDF data stencils from PDF forms
+* Apply a background watermark or a foreground stamp
+* Report PDF metrics, bookmarks and metadata
+* Add/update PDF bookmarks or metadata
+* Attach files to PDF pages or the PDF document
+* Unpack PDF attachments
+* Burst a PDF document into single pages
+* Uncompress and re-compress page streams
+* Repair corrupted PDF (where possible)
+
+## Installation
+
+To install PDFtk Server, first install Homebrew by running this command at the
+shell prompt:
+
+```
+$ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+```
+
+See the [Homebrew installation
+instructions](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Installation.md#installation)
+for more information.
+
+Then, use [`brew
+tap`](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/brew-tap.md#brew-tap)
+to track the
+[`docmunch/homebrew-pdftk`](https://github.com/docmunch/homebrew-pdftk)
+repository:
+
+```
+$ brew tap docmunch/pdftk
+```
+
+Finally, install the `pdftk` formula:
+
+```
+$ brew install pdftk
+```
+
+Note that this formula requires the
+[`ecj`](https://github.com/Homebrew/homebrew/blob/master/Library/Formula/ecj.rb)
+(for Java) and
+[`gcc`](https://github.com/Homebrew/homebrew/blob/master/Library/Formula/gcc.rb)
+(for `gcj`) formulas. By default, it requires `gcc` with the
+`--with-all-languages` flag. You can pass `--with-java` to `brew install pdftk`
+if you prefer to install `gcc` with only Java support (or if you already have
+that version of `gcc` installed).
+
+To confirm that installation worked:
+
+```
+$ which pdftk
+/usr/local/bin/pdftk
+$ pdftk --version
+
+pdftk 2.02 a Handy Tool for Manipulating PDF Documents
+Copyright (c) 2003-13 Steward and Lee, LLC - Please Visit: www.pdftk.com
+This is free software; see the source code for copying conditions. There is
+NO warranty, not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+```
+
+## Usage
+
+Typing `pdftk` at the shell prompt gives you a summary of commands:
+
+```
+$ pdftk
+SYNOPSIS
+       pdftk <input PDF files | - | PROMPT>
+            [ input_pw <input PDF owner passwords | PROMPT> ]
+            [ <operation> <operation arguments> ]
+            [ output <output filename | - | PROMPT> ]
+            [ encrypt_40bit | encrypt_128bit ]
+            [ allow <permissions> ]
+            [ owner_pw <owner password | PROMPT> ]
+            [ user_pw <user password | PROMPT> ]
+            [ flatten ] [ need_appearances ]
+            [ compress | uncompress ]
+            [ keep_first_id | keep_final_id ] [ drop_xfa ] [ drop_xmp ]
+            [ verbose ] [ dont_ask | do_ask ]
+       Where:
+            <operation> may be empty, or:
+            [ cat | shuffle | burst | rotate |
+              generate_fdf | fill_form |
+              background | multibackground |
+              stamp | multistamp |
+              dump_data | dump_data_utf8 |
+              dump_data_fields | dump_data_fields_utf8 |
+              dump_data_annots |
+              update_info | update_info_utf8 |
+              attach_files | unpack_files ]
+
+       For Complete Help: pdftk --help
+```
+
+For a detailed description, refer to the man page:
+
+```
+$ man pdftk
+```

--- a/patch.diff
+++ b/patch.diff
@@ -25,7 +25,7 @@ index 8f7e52d..390c974 100644
 -TOOLPATH=/sw/lib/gcc4.5/bin/
 -export VERSUFF=-fsf-4.5
 +TOOLPATH=@HOMEBREW_PREFIX@/bin/
-+export VERSUFF=@GCC_TOOL_VERSION@
++export VERSUFF=-@GCC_VERSION_SUFFIX@
  export CXX= $(TOOLPATH)g++$(VERSUFF)
  export GCJ= $(TOOLPATH)gcj$(VERSUFF)
  export GCJH= $(TOOLPATH)gcjh$(VERSUFF)
@@ -46,6 +46,6 @@ index 8f7e52d..390c974 100644
  export GCJFLAGS= -Wall -fsource=1.3 -O2
  export GCJHFLAGS= -force
 -export LDLIBS= /sw/lib/gcc4.5/lib/libgcj.dylib /sw/lib/gcc4.5/lib/libstdc++.dylib /sw/lib/gcc4.5/lib/libgcc_s.1.dylib -liconv -lz
-+export LDLIBS= @PREFIX@/lib/gcc/@BUILD@/@GCC_VERSION@/libgcj.dylib @PREFIX@/lib/gcc/@BUILD@/@GCC_VERSION@/libstdc++.dylib @PREFIX@/lib/gcc/@BUILD@/@GCC_VERSION@/libgcc_s.1.dylib -liconv -lz
++export LDLIBS= @PREFIX@/lib/gcc/@GCC_VERSION_SUFFIX@/libgcj.dylib @PREFIX@/lib/gcc/@GCC_VERSION_SUFFIX@/libstdc++.dylib @PREFIX@/lib/gcc/@GCC_VERSION_SUFFIX@/libgcc_s.1.dylib -liconv -lz
  
  include Makefile.Base

--- a/pdftk.rb
+++ b/pdftk.rb
@@ -6,11 +6,11 @@ class Pdftk < Formula
 
   head 'https://github.com/docmunch/pdftk.git', :branch => 'master'
 
-  depends_on 'ecj' => :build
-  depends_on 'Homebrew/versions/gcc48' => [:build, 'enable-all-languages'] # or 'enable-java'
+  depends_on 'ecj'
+  depends_on 'gcc' => ['with-all-languages'] # or 'with-java'
 
   def patches
-    'https://raw.githubusercontent.com/docmunch/homebrew-pdftk/fbe14dbb13d65a6847fc70ad521719ea9ad1353f/patch.diff'
+    'https://raw.githubusercontent.com/docmunch/homebrew-pdftk/master/patch.diff'
   end
 
   def install
@@ -22,12 +22,12 @@ class Pdftk < Formula
     man1.install 'pdftk.1'
 
     cd 'pdftk' do
+      gcc = Formula['gcc']
       inreplace 'Makefile.OSX-10.6' do |s|
         s.gsub! '@HOMEBREW_PREFIX@', HOMEBREW_PREFIX
-        s.gsub! '@PREFIX@', Formula.factory('gcc48').prefix
-        s.gsub! '@GCC_TOOL_VERSION@', "#{Formula.factory('gcc48').version}".sub(/(\d\.\d).*/,'-\1')
-        s.gsub! '@GCC_VERSION@', Formula.factory('gcc48').version
-        s.gsub! '@BUILD@', "#{Formula.factory('gcc48').arch}-apple-darwin#{Formula.factory('gcc48').osmajor}"
+        s.gsub! '@PREFIX@', gcc.prefix
+        s.gsub! '@GCC_VERSION@', gcc.version
+        s.gsub! '@GCC_VERSION_SUFFIX@', gcc.version_suffix
       end
 
       system 'make', '-f', 'Makefile.OSX-10.6'

--- a/pdftk.rb
+++ b/pdftk.rb
@@ -6,8 +6,11 @@ class Pdftk < Formula
 
   head 'https://github.com/docmunch/pdftk.git', :branch => 'master'
 
+  option "with-java", "Build gcc using --with-java instead of --with-all-languages"
+
   depends_on 'ecj'
-  depends_on 'gcc' => ['with-all-languages'] # or 'with-java'
+  depends_on 'gcc' => ['with-java'] if build.with?("java")
+  depends_on 'gcc' => ['with-all-languages'] if !build.with?("java")
 
   def patches
     'https://raw.githubusercontent.com/docmunch/homebrew-pdftk/master/patch.diff'


### PR DESCRIPTION
Summary of changes:
- Use `gcc` as a dependency instead of `gcc48`
- Remove `:build` from the dependencies, since (I think) `pdftk` needs the Java libs even after building
- Fix the paths used in the `Makefile`
- Add a `--with-java` flag to build `gcc` using `--with-java` instead of `--with-all-languages` (the default)
- Add a `README.md`
